### PR TITLE
출력 포맷 오류 수정

### DIFF
--- a/수정/main.py
+++ b/수정/main.py
@@ -75,7 +75,8 @@ def initialize_rag_system():
         question_validator=prompts.get("question_validator"),  # 프롬프트 전달
         web_search_tool=web_search_tool,  # 웹 검색 도구 전달
         rag_metrics=rag_metrics,  # RAG 메트릭스 전달
-        image_route_router=prompts.get("image_route_router")  # 이미지 라우팅 라우터 전달
+        image_route_router=prompts.get("image_route_router"),  # 이미지 라우팅 라우터 전달
+        rag_prompt=prompts.get("rag_prompt"),
     )
     
     # 9. 워크플로우 구성

--- a/수정/nodes.py
+++ b/수정/nodes.py
@@ -11,15 +11,16 @@ from .utils import get_current_question, preserve_state_fields, get_current_imag
 from .error_handler import robust_error_handling, ErrorType
 from .location import get_location_context
 from .image import image_classification_model, image_classification_processor, all_classes
+from langchain_core.output_parsers import StrOutputParser
 
 
 # 노드 함수들은 전역 변수에 의존하므로 초기화 함수 필요
 def initialize_nodes(rag_pipeline, llm, crop_retrievers, reranker, free_reranker_func=None, 
                      question_router=None, question_validator=None, web_search_tool=None,
-                     rag_metrics=None, image_route_router=None):
+                     rag_metrics=None, image_route_router=None, rag_prompt=None):
     """노드 함수들을 초기화하는 함수 (전역 변수 설정)"""
     global _rag_pipeline, _llm, _crop_retrievers, _reranker, _free_reranker
-    global _question_router, _question_validator, _web_search_tool, _rag_metrics, _image_route_router
+    global _question_router, _question_validator, _web_search_tool, _rag_metrics, _image_route_router, _rag_prompt
     
     _rag_pipeline = rag_pipeline
     _llm = llm
@@ -31,7 +32,7 @@ def initialize_nodes(rag_pipeline, llm, crop_retrievers, reranker, free_reranker
     _web_search_tool = web_search_tool
     _rag_metrics = rag_metrics
     _image_route_router = image_route_router
-
+    _rag_prompt = rag_prompt
 
 # 전역 변수 (initialize_nodes로 설정됨)
 _rag_pipeline = None
@@ -44,6 +45,7 @@ _question_validator = None
 _web_search_tool = None
 _rag_metrics = None
 _image_route_router = None
+_rag_prompt = None
 
 def retrieval_node(state: GraphState) -> GraphState:
     """검색 노드 - RAG의 핵심"""
@@ -132,13 +134,16 @@ def generation_node(state: GraphState) -> GraphState:
     debug_print("==== [GENERATION NODE] ====")
     question = state["question"]
     context = state["context"]
+    image_result = state.get("image_result", "")
     
     try:
         location_context = get_location_context()
         if location_context and "경작지 위치 정보가 설정되지 않았습니다" not in location_context:
             enhanced_context = f"{context}\n\n{location_context}"
+            farm_info = location_context
         else:
             enhanced_context = context
+            farm_info = "경작지 위치 정보가 설정되지 않았습니다"
 
 
         if _rag_pipeline is None or _rag_pipeline.rag_chain is None:
@@ -148,17 +153,21 @@ def generation_node(state: GraphState) -> GraphState:
                     "status": "error",
                     "error_message": "LLM not initialized"
                 }
+            fallback_prompt = _rag_prompt
+            chain = fallback_prompt | _llm | StrOutputParser()
             
-            fallback_prompt = f"""
-다음 컨텍스트를 바탕으로 질문에 답변해주세요:
+#             fallback_prompt = f"""
+# 다음 컨텍스트를 바탕으로 질문에 답변해주세요:
 
-컨텍스트: {enhanced_context}
+# 컨텍스트: {enhanced_context}
 
-질문: {question}
+# 질문: {question}
 
-답변:
-"""
-            answer = _llm.invoke(fallback_prompt).content
+# 답변:
+# """
+            # answer = _llm.invoke(fallback_prompt).content
+
+            answer = chain.invoke({"question":question, "context":enhanced_context, "farm_info":farm_info, "image_result":image_result})
             return {
                 "answer": answer,
                 "status": "fallback_generated"

--- a/수정/prompts.py
+++ b/수정/prompts.py
@@ -4,6 +4,7 @@ LLM 프롬프트 초기화
 """
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
+from langchain_core.output_parsers import StrOutputParser
 from .models import RouteQuery, QuestionValidity
 from .config import MODEL_NAME
 
@@ -288,6 +289,10 @@ def setup_llm_and_prompts(llm=None):
 위 정보를 바탕으로 질문에 대한 정확하고 전문적인 답변을 제공해주세요.
         """),
     ])
+
+
+
+
     
     # 평가용 프롬프트들
     grade_documents_prompt = ChatPromptTemplate.from_messages([
@@ -351,6 +356,7 @@ Otherwise, use web-search.""",),
     hallucination_grader = hallucination_grader_prompt | llm.with_structured_output(GradeHallucinations)
     answer_grader = answer_grader_prompt | llm.with_structured_output(GradeAnswer)
     image_route_router = image_route_prompt | llm.with_structured_output(ImageRouteQuery)
+    rag_chain = rag_prompt | llm | StrOutputParser()
 
     return {
         "llm": llm,
@@ -366,4 +372,5 @@ Otherwise, use web-search.""",),
         "answer_grader": answer_grader,
         # 이미지 분석 체인
         "image_route_router": image_route_router,
+        "rag_chain": rag_chain,
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches fallback answer generation to a `rag_prompt | llm | StrOutputParser` chain, passes `rag_prompt` into nodes, and exports `rag_chain` from prompts.
> 
> - **RAG Generation (fallback)**:
>   - Use `rag_prompt | llm | StrOutputParser` instead of ad-hoc string prompt in `nodes.generation_node`.
>   - Inject `farm_info` and `image_result` into the fallback chain inputs.
> - **Initialization**:
>   - Pass `prompts["rag_prompt"]` to `nodes.initialize_nodes` in `main.py`.
>   - Add `_rag_prompt` global handling in `nodes.initialize_nodes`.
> - **Prompts**:
>   - Create and export `rag_chain` (`rag_prompt | llm | StrOutputParser`).
>   - Import `StrOutputParser` to support the new chain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c162fe217410406d2ac274a356301ab0960538a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->