### PR TITLE
이미지 분석 노드 위치 변경

### DIFF
--- a/수정/__init__.py
+++ b/수정/__init__.py
@@ -11,7 +11,6 @@ from .models import (
     GradeDocuments,
     GradeHallucinations,
     GradeAnswer,
-    ImageRouteQuery
 )
 from .config import DEBUG_MODE, MODEL_NAME, debug_print
 from .utils import get_current_question, preserve_state_fields, format_docs
@@ -53,7 +52,6 @@ __all__ = [
     "GradeDocuments",
     "GradeHallucinations",
     "GradeAnswer",
-    "ImageRouteQuery",
     # Config
     "DEBUG_MODE",
     "MODEL_NAME",

--- a/수정/main.py
+++ b/수정/main.py
@@ -2,17 +2,19 @@
 메인 실행 모듈
 RAG 시스템 통합 및 실행 함수
 """
+import os
 from typing import Dict, Any
 from langchain_core.runnables import RunnableConfig
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_teddynote.messages import random_uuid
 from .config import MODEL_NAME, debug_print
 from .retrieval import setup_all_crop_retrievers, setup_reranker, setup_web_search_tool
-from .metrics import RAGMetrics
 from .prompts import setup_llm_and_prompts
 from .nodes import initialize_nodes
 from .workflow import create_workflow
 from .location import get_location_context
+from .weather_forecast import WeatherForecastManager
+from .pest_forecast import PestForecastPredictor
 
 
 def initialize_rag_system():
@@ -44,23 +46,39 @@ def initialize_rag_system():
     debug_print("🌐 웹 검색 도구 설정 중...")
     web_search_tool = setup_web_search_tool()
     
-    # 6. RAG 파이프라인 설정 (하이브리드 검색 제거)
+    # 6. 기상 예보 및 병해충 예측 모듈 초기화
+    debug_print("🌤️ 기상 예보 모듈 초기화 중...")
+    weather_manager = None
+    pest_predictor = None
+    try:
+        # 기상 예보 매니저 초기화
+        weather_manager = WeatherForecastManager()
+        debug_print("✅ 기상 예보 모듈 초기화 완료")
+        
+        pest_predictor = PestForecastPredictor(weather_manager, crop_retrievers)
+        debug_print("✅ 병해충 예측 모듈 초기화 완료")
+        
+        # 벡터스토어에서 병해충 목록 자동 추출 (선택사항)
+        try:
+            debug_print("🔍 벡터스토어에서 병해충 목록 추출 중...")
+            for crop in ["토마토", "딸기"]:
+                pest_info = pest_predictor.get_all_pests_for_crop(crop)
+                debug_print(f"📊 {crop} 병해충 정보:")
+                debug_print(f"   - 예보 기반 예측 가능: {pest_info['total_forecast_pests']}개")
+                debug_print(f"   - 벡터스토어 전체: {pest_info['total_vectorstore_pests']}개")
+                debug_print(f"   - 예측 규칙 누락: {pest_info['missing_count']}개")
+                if pest_info['missing_predictions']:
+                    debug_print(f"   - 누락된 병해충: {', '.join(pest_info['missing_predictions'][:5])}{'...' if len(pest_info['missing_predictions']) > 5 else ''}")
+        except Exception as e:
+            debug_print(f"⚠️ 병해충 목록 추출 실패 (시스템은 정상 작동): {e}")
+    except Exception as e:
+        debug_print(f"⚠️ 기상/병해충 모듈 초기화 실패: {e}")
+        debug_print("💡 기상 데이터 없이 RAG 시스템을 계속 실행합니다.")
+    
+    # 7. RAG 파이프라인 설정 (하이브리드 검색 제거)
     # rag_pipeline을 None으로 설정하여 fallback 모드 사용 (crop_retrievers 직접 사용)
     rag_pipeline = None
     debug_print("📚 RAG 파이프라인: 기본 검색 모드 사용 (벡터스토어 직접 검색)")
-    
-    # 7. RAG 메트릭스 초기화 (LLM 기반 평가 사용)
-    debug_print("📊 RAG 메트릭스 초기화 중...")
-    rag_metrics = RAGMetrics(
-        embedding_model=embedding_model,
-        llm=llm,
-        grade_documents_grader=prompts.get("grade_documents_grader"),
-        hallucination_grader=prompts.get("hallucination_grader"),
-        answer_grader=prompts.get("answer_grader")
-    )
-    
-    # rag_pipeline이 None이므로 rag_metrics는 별도로 관리
-    # (rag_pipeline이 있을 때만 업데이트)
     
     # 8. 노드 함수 초기화
     debug_print("🔧 노드 함수 초기화 중...")
@@ -74,9 +92,9 @@ def initialize_rag_system():
         question_router=prompts.get("question_router"),  # 프롬프트 전달
         question_validator=prompts.get("question_validator"),  # 프롬프트 전달
         web_search_tool=web_search_tool,  # 웹 검색 도구 전달
-        rag_metrics=rag_metrics,  # RAG 메트릭스 전달
-        image_route_router=prompts.get("image_route_router"),  # 이미지 라우팅 라우터 전달
-        rag_prompt=prompts.get("rag_prompt"),
+        weather_manager=weather_manager,  # 기상 예보 관리자 전달
+        pest_predictor=pest_predictor,  # 병해충 예측 모듈 전달
+        rag_prompt=prompts.get("rag_prompt")  # RAG 프롬프트 전달
     )
     
     # 9. 워크플로우 구성
@@ -91,8 +109,8 @@ def initialize_rag_system():
         "retrieval_node": nodes.retrieval_node,
         "augmentation_node": nodes.augmentation_node,
         "generation_node": nodes.generation_node,
-        "quality_check_node": nodes.quality_check_node,
-        "llm_judge_validation": nodes.llm_judge_validation_node,
+        "answer_refinement_node": nodes.answer_refinement_node,  # 답변 정리 노드 (보강 및 정리만)
+        "llm_judge_node": nodes.llm_judge_node,  # LLM Judge 노드 (품질 평가 및 검증)
         "analyze_image": nodes.analyze_image,
     }
     
@@ -104,7 +122,6 @@ def initialize_rag_system():
         "app": app,
         "llm": llm,
         "embedding_model": embedding_model,
-        "rag_metrics": rag_metrics,
         "crop_retrievers": crop_retrievers,
         "reranker": reranker,
         "web_search_tool": web_search_tool,
@@ -147,9 +164,23 @@ def run_rag_system(question: str, image_path: str = None, config: Dict[str, Any]
     result = app.invoke(inputs, run_config)
     
     # 결과 출력
-    debug_print(f"\n💬 답변:")
-    debug_print("-" * 50)
-    debug_print(result.get("answer", result.get("generation", "답변을 생성할 수 없습니다.")))
+    original_answer = result.get("original_answer", "")
+    refined_answer = result.get("answer", result.get("generation", "답변을 생성할 수 없습니다."))
+    
+    if original_answer and original_answer != refined_answer:
+        # 원본 답변과 보강된 답변 모두 출력
+        debug_print(f"\n📝 원본 RAG 답변:")
+        debug_print("-" * 50)
+        debug_print(original_answer)
+        debug_print("\n" + "=" * 50)
+        debug_print(f"\n✨ 보강된 RAG 답변:")
+        debug_print("-" * 50)
+        debug_print(refined_answer)
+    else:
+        # 정리되지 않은 경우 원본 답변만 출력
+        debug_print(f"\n💬 답변:")
+        debug_print("-" * 50)
+        debug_print(refined_answer)
     
     # 이미지 분석 결과 출력
     if image_path:

--- a/수정/models.py
+++ b/수정/models.py
@@ -2,7 +2,7 @@
 데이터 모델 정의 모듈
 Pydantic 모델 및 타입 정의
 """
-from typing import List, Literal, Annotated, Dict, Any
+from typing import List, Literal, Annotated, Dict, Any, Optional
 from typing_extensions import TypedDict
 from pydantic import BaseModel, Field
 from langchain_core.documents import Document
@@ -10,7 +10,7 @@ from langchain_core.documents import Document
 
 class RouteQuery(BaseModel):
     """사용자 쿼리를 가장 관련성 높은 데이터 소스로 라우팅하는 데이터 모델"""
-    datasource: Literal["vectorstore", "web_search", "image_analysis"] = Field(
+    datasource: Literal["vectorstore", "web_search"] = Field(
         ...,
         description="""농업 질문을 분석하여 적절한 데이터 소스로 라우팅하세요.
         
@@ -25,11 +25,7 @@ class RouteQuery(BaseModel):
 - 농업과 무관한 일반적인 질문
 - 딸기나 토마토 벡터스토어에 정보가 부족한 질문
 
-**image_analysis 선택 조건:**
-- 이미지가 포함된 질문
-- 이미지에 대한 분석이 필요한 질문
-
-반드시 "vectorstore" 또는 "web_search" 또는 "image_analysis" 중 하나만 선택하세요.""",
+반드시 "vectorstore" 또는 "web_search" 중 하나만 선택하세요.""",
     )
 
 
@@ -118,19 +114,19 @@ class LLMJudgeScores(BaseModel):
     )
     overall_score: int = Field(
         description="""종합 평가 점수 (0-100점)
-- 위 4개 항목(accuracy, completeness, logical_consistency, usefulness)의 평균값
-- 각 항목의 중요도를 고려하여 계산
-- 70점 이상이면 유효한 답변으로 간주
+- 위 4개 항목(accuracy, completeness, logical_consistency, usefulness)을 종합적으로 평가
+- 각 항목의 중요도를 고려하여 계산하세요
+- 정확성과 완전성을 더 중요하게 평가하세요
 
-정확성과 완전성을 더 중요하게 평가하세요.""",
+**⚠️ 중요**: 임계값 없이 답변의 품질을 종합적으로 판단하여 점수를 부여하세요.""",
         ge=0, le=100
     )
     is_valid: bool = Field(
         description="""답변이 유효한지 여부
-- 모든 점수가 70점 이상이고 overall_score가 70점 이상이면 True
-- 그렇지 않으면 False
+- 답변의 품질을 종합적으로 판단하여 True/False 결정
+- 농업 정보의 정확성과 신뢰성을 고려하여 판단하세요
 
-농업 정보의 정확성과 신뢰성이 중요하므로 기준을 엄격하게 적용하세요.""",
+**⚠️ 중요**: 임계값 없이 답변의 전체적인 품질을 평가하여 판단하세요.""",
     )
     reasoning: str = Field(
         description="""평가 근거를 상세히 설명하세요.
@@ -149,11 +145,12 @@ class LLMJudgeScores(BaseModel):
 - False: 답변이 부정확하거나 불완전하여 재처리 필요
 
 판단 기준:
-1. accuracy와 completeness가 모두 70점 이상
-2. overall_score가 70점 이상
-3. 참조 문서에 충분히 근거하고 있음
-4. 논리적으로 일관되고 유용함
+1. 참조 문서에 충분히 근거하고 있는가?
+2. 논리적으로 일관되고 유용한가?
+3. 질문에 대한 답변이 완전한가?
+4. 실제 농업 현장에서 적용 가능한가?
 
+**⚠️ 중요**: 임계값 없이 답변의 전체적인 품질을 종합적으로 판단하여 결정하세요.
 농업 정보의 정확성이 매우 중요하므로, 확신이 없으면 False를 선택하세요.""",
     )
     
@@ -240,13 +237,6 @@ class GradeAnswer(BaseModel):
                    "답변이 질문을 직접적으로 해결하면 'yes', 그렇지 않으면 'no'를 반환하세요."
     )
 
-
-class ImageRouteQuery(BaseModel):
-    """Route a user question to the most relevant datasource after image analysis."""
-    datasource: Literal["vectorstore", "web_search"] = Field(
-        ...,
-        description="Given a user question choose to route it to web search, vectorstore.",
-    )
     
 
 class GraphState(TypedDict):
@@ -284,6 +274,7 @@ class GraphState(TypedDict):
     retrieved_docs: Annotated[List[Document], "Retrieved documents"]
     context: Annotated[str, "Formatted context from documents"]
     answer: Annotated[str, "Generated answer"]
+    original_answer: Annotated[str, "Original RAG answer before refinement"]
     quality_scores: Annotated[Dict[str, float], "RAG quality scores"]
     status: Annotated[str, "Processing status"]
     llm_judge_scores: Annotated[Dict[str, Any], "LLM Judge scores"]

--- a/수정/nodes.py
+++ b/수정/nodes.py
@@ -7,9 +7,9 @@ from langchain_core.documents import Document
 from langchain_core.prompts import ChatPromptTemplate
 from .models import GraphState, LLMJudgeScores
 from .config import debug_print
-from .utils import get_current_question, preserve_state_fields, get_current_image
+from .utils import get_current_question, preserve_state_fields, get_current_image, format_docs
 from .error_handler import robust_error_handling, ErrorType
-from .location import get_location_context
+from .location import get_location_context, get_farm_info
 from .image import image_classification_model, image_classification_processor, all_classes
 from langchain_core.output_parsers import StrOutputParser
 
@@ -17,10 +17,11 @@ from langchain_core.output_parsers import StrOutputParser
 # 노드 함수들은 전역 변수에 의존하므로 초기화 함수 필요
 def initialize_nodes(rag_pipeline, llm, crop_retrievers, reranker, free_reranker_func=None, 
                      question_router=None, question_validator=None, web_search_tool=None,
-                     rag_metrics=None, image_route_router=None, rag_prompt=None):
+                     weather_manager=None, pest_predictor=None, rag_prompt=None):
     """노드 함수들을 초기화하는 함수 (전역 변수 설정)"""
     global _rag_pipeline, _llm, _crop_retrievers, _reranker, _free_reranker
-    global _question_router, _question_validator, _web_search_tool, _rag_metrics, _image_route_router, _rag_prompt
+    global _question_router, _question_validator, _web_search_tool, _rag_prompt
+    global _weather_manager, _pest_predictor
     
     _rag_pipeline = rag_pipeline
     _llm = llm
@@ -30,9 +31,10 @@ def initialize_nodes(rag_pipeline, llm, crop_retrievers, reranker, free_reranker
     _question_router = question_router
     _question_validator = question_validator
     _web_search_tool = web_search_tool
-    _rag_metrics = rag_metrics
-    _image_route_router = image_route_router
+    _weather_manager = weather_manager
+    _pest_predictor = pest_predictor
     _rag_prompt = rag_prompt
+
 
 # 전역 변수 (initialize_nodes로 설정됨)
 _rag_pipeline = None
@@ -43,15 +45,14 @@ _free_reranker = None
 _question_router = None
 _question_validator = None
 _web_search_tool = None
-_rag_metrics = None
-_image_route_router = None
+_weather_manager = None
+_pest_predictor = None
 _rag_prompt = None
 
 def retrieval_node(state: GraphState) -> GraphState:
     """검색 노드 - RAG의 핵심"""
     debug_print("==== [RETRIEVAL NODE] ====")
     question = state["question"]
-    image_result = state.get("image_result", "")
 
     try:
         location_context = get_location_context()
@@ -105,10 +106,7 @@ def augmentation_node(state: GraphState) -> GraphState:
             }
         
         if _rag_pipeline is None:
-            context = "\n\n".join([
-                f"문서 {i+1}: {doc.page_content}\n출처: {doc.metadata.get('source', 'Unknown')}"
-                for i, doc in enumerate(documents)
-            ])
+            context = format_docs(documents)  # utils.format_docs 사용
             return {
                 "context": context,
                 "status": "fallback_augmented"
@@ -137,13 +135,85 @@ def generation_node(state: GraphState) -> GraphState:
     image_result = state.get("image_result", "")
     
     try:
+        # 현재 날짜 정보 가져오기
+        from datetime import datetime
+        current_date = datetime.now()
+        current_date_str = current_date.strftime("%Y년 %m월 %d일")
+        current_month = current_date.month
+        current_season = ""
+        if current_month in [12, 1, 2]:
+            current_season = "겨울"
+        elif current_month in [3, 4, 5]:
+            current_season = "봄"
+        elif current_month in [6, 7, 8]:
+            current_season = "여름"
+        elif current_month in [9, 10, 11]:
+            current_season = "가을"
+        
+        date_context = f"📅 현재 날짜: {current_date_str} ({current_season})"
+        
+        # 위치 컨텍스트
         location_context = get_location_context()
+        
+        # 기상 데이터 컨텍스트 추가
+        weather_context = ""
+        pest_forecast_context = ""
+        
+        farm_info = get_farm_info()
+        if farm_info and _weather_manager:
+            latitude = farm_info.get('latitude')
+            longitude = farm_info.get('longitude')
+            
+            if latitude and longitude:
+                # 기상 컨텍스트 (질문에서 날짜 추출하여 적절한 데이터 사용)
+                weather_context = _weather_manager.get_weather_for_date(
+                    latitude, longitude, question=question
+                )
+                
+                # 병해충 예측 컨텍스트 (질문에서 작물 추출)
+                if _pest_predictor:
+                    # 질문에서 작물명 추출
+                    question_lower = question.lower()
+                    crop = None
+                    growth_stage = "생육기"  # 기본값
+                    
+                    if "토마토" in question or "tomato" in question_lower:
+                        crop = "토마토"
+                    elif "딸기" in question or "strawberry" in question_lower:
+                        crop = "딸기"
+                    
+                    # 생육 단계 추출 (선택사항)
+                    if "개화" in question or "개화기" in question:
+                        growth_stage = "개화기"
+                    elif "착과" in question or "착과기" in question:
+                        growth_stage = "착과기"
+                    elif "수확" in question or "수확기" in question:
+                        growth_stage = "수확기"
+                    
+                    if crop:
+                        pest_forecast_context = _pest_predictor.get_pest_forecast_context(
+                            latitude, longitude, crop, growth_stage
+                        )
+        
+        # 컨텍스트 통합
+        enhanced_context = context
+        # 날짜 정보를 맨 앞에 추가
+        enhanced_context = f"{date_context}\n\n{enhanced_context}"
         if location_context and "경작지 위치 정보가 설정되지 않았습니다" not in location_context:
-            enhanced_context = f"{context}\n\n{location_context}"
-            farm_info = location_context
-        else:
-            enhanced_context = context
-            farm_info = "경작지 위치 정보가 설정되지 않았습니다"
+            enhanced_context = f"{enhanced_context}\n\n{location_context}"
+        if weather_context:
+            enhanced_context = f"{enhanced_context}\n\n{weather_context}"
+            debug_print(f"✅ 기상 컨텍스트 추가됨: {weather_context[:100]}...")
+        if pest_forecast_context:
+            enhanced_context = f"{enhanced_context}\n\n{pest_forecast_context}"
+            debug_print(f"✅ 병해충 예측 컨텍스트 추가됨: {pest_forecast_context[:100]}...")
+        
+        # 디버그: 최종 컨텍스트 확인
+        if weather_context or pest_forecast_context:
+            debug_print(f"📊 통합된 컨텍스트 길이: {len(enhanced_context)} 문자")
+            debug_print(f"📊 기상 정보 포함 여부: {'✅' if weather_context else '❌'}")
+            debug_print(f"📊 병해충 예측 포함 여부: {'✅' if pest_forecast_context else '❌'}")
+        debug_print(f"📅 현재 날짜 정보 추가됨: {current_date_str} ({current_season})")
 
 
         if _rag_pipeline is None or _rag_pipeline.rag_chain is None:
@@ -153,21 +223,11 @@ def generation_node(state: GraphState) -> GraphState:
                     "status": "error",
                     "error_message": "LLM not initialized"
                 }
+            
             fallback_prompt = _rag_prompt
             chain = fallback_prompt | _llm | StrOutputParser()
-            
-#             fallback_prompt = f"""
-# 다음 컨텍스트를 바탕으로 질문에 답변해주세요:
 
-# 컨텍스트: {enhanced_context}
-
-# 질문: {question}
-
-# 답변:
-# """
-            # answer = _llm.invoke(fallback_prompt).content
-
-            answer = chain.invoke({"question":question, "context":enhanced_context, "farm_info":farm_info, "image_result":image_result})
+            answer = chain.invoke({"question": question, "context": enhanced_context, "farm_info": farm_info, "image_result": image_result})
             return {
                 "answer": answer,
                 "status": "fallback_generated"
@@ -189,146 +249,202 @@ def generation_node(state: GraphState) -> GraphState:
         }
 
 
-def quality_check_node(state: GraphState) -> GraphState:
-    """품질 검사 노드 - RAG 품질 평가"""
-    debug_print("==== [QUALITY CHECK NODE] ====")
-    question = state["question"]
+def answer_refinement_node(state: GraphState) -> GraphState:
+    """답변 정리 노드 - RAG 답변만 보강 (ChatGPT 자체 지식 사용 안 함)"""
+    debug_print("==== [ANSWER REFINEMENT NODE] ====")
+    question = state.get("question", "")
+    rag_answer = state.get("answer", "")
+    retry_count = state.get("retry_count", 0)
+    route = state.get("route", "vectorstore")
     documents = state.get("retrieved_docs", state.get("documents", []))
-    answer = state["answer"]
     
     try:
-        if not documents:
+        if not rag_answer or rag_answer.strip() == "":
+            debug_print("⚠️ RAG 답변이 없어 정리 건너뜀")
+            return state
+        
+        # ⭐ RAG 답변 출력
+        debug_print("=" * 80)
+        debug_print("📄 [RAG 시스템 답변]")
+        debug_print("=" * 80)
+        debug_print(rag_answer)
+        debug_print("=" * 80)
+        debug_print(f"📏 RAG 답변 길이: {len(rag_answer)} 문자")
+        
+        if _llm is None:
+            debug_print("⚠️ LLM이 없어 정리 건너뜀")
+            return state
+        
+        # RAG 답변만 받아서 보강/개선 (ChatGPT 자체 지식 사용 안 함)
+        try:
+            debug_print("🔧 RAG 답변 보강 중...")
+            
+            # 검색된 문서 정보 추가 (참고용)
+            doc_summary = ""
+            if documents:
+                doc_summary = "\n\n=== 참조 문서 요약 ===\n"
+                for i, doc in enumerate(documents[:5]):  # 상위 5개만
+                    content = doc.page_content[:200] if hasattr(doc, 'page_content') else str(doc)[:200]
+                    source = doc.metadata.get("source", "Unknown")
+                    doc_summary += f"\n[문서 {i+1}] 출처: {source}\n{content}...\n"
+            
+            # RAG 답변 보강 프롬프트
+            enhancement_prompt = f"""당신은 농업 전문가이자 답변 개선 전문가입니다.
+다음 RAG 시스템이 검색한 문서 기반 답변을 보강하고 개선하세요.
+
+**원본 질문:**
+{question}
+
+**RAG 시스템 답변 (검색된 문서 기반):**
+{rag_answer}
+
+**참조 문서 (참고용):**
+{doc_summary if doc_summary else "참조 문서 없음"}
+
+## 작업 지시사항
+
+### ✅ 수행할 작업:
+1. **내용 보강**: 
+   - RAG 답변에 이미 포함된 정보를 더 명확하게 표현
+   - 불완전한 설명을 보완 (단, 검색된 문서에 근거한 정보만)
+   - 논리적 흐름 개선
+
+2. **구조화 및 가독성 개선**:
+   - 불필요한 중복 제거
+   - 문장을 자연스럽게 다듬기
+   - 마크다운 형식 활용 (제목, 목록, 강조 등)
+   - 단락 구분 및 구조 정리
+
+3. **정보 정확성 유지**:
+   - RAG 답변의 모든 핵심 정보는 그대로 유지
+   - 수치, 시기, 방법 등 구체적 정보는 변경하지 않음
+   - 검색된 문서에 나온 정보만 사용
+
+### ❌ 금지 사항:
+1. **새로운 정보 추가 금지**: 
+   - 검색된 문서에 없는 정보를 추가하지 마세요
+   - ChatGPT의 자체 지식을 사용하지 마세요
+   - 추측이나 일반적인 농업 지식을 추가하지 마세요
+
+2. **내용 변경 금지**:
+   - RAG 답변의 핵심 내용을 변경하지 마세요
+   - 수치, 시기, 방법 등 구체적 정보는 그대로 유지하세요
+   - 문서에 나온 정보와 다른 내용으로 변경하지 마세요
+
+3. **모순 정보 추가 금지**:
+   - RAG 답변과 모순되는 정보를 추가하지 마세요
+   - 질문과 무관한 정보를 추가하지 마세요
+
+## 보강 원칙
+
+- **RAG 답변 기본 유지**: RAG 답변의 모든 핵심 정보는 그대로 유지
+- **표현 개선만**: 같은 내용을 더 명확하고 읽기 쉽게 표현
+- **구조화만**: 정보를 더 잘 구조화하여 가독성 향상
+- **문서 기반만**: 검색된 문서에 나온 정보만 사용
+
+위 RAG 답변을 보강하여 개선된 답변을 생성하세요. 새로운 정보를 추가하지 말고, 기존 RAG 답변의 내용을 더 명확하고 읽기 쉽게 개선하세요.
+"""
+            
+            enhanced_answer = _llm.invoke(enhancement_prompt).content
+            debug_print("✅ RAG 답변 보강 완료")
+            debug_print(f"📏 보강된 답변 길이: {len(enhanced_answer)} 문자")
+            
+            # ⭐ 보강된 답변 출력
+            debug_print("=" * 80)
+            debug_print("✨ [보강된 RAG 답변]")
+            debug_print("=" * 80)
+            debug_print(enhanced_answer)
+            debug_print("=" * 80)
+            
             return {
-                "quality_scores": {
-                    "retrieval_accuracy": 0.2,
-                    "answer_relevance": 0.3,
-                    "answer_correctness": 0.2,
-                    "hallucination_score": 0.5,
-                    "overall_score": 0.3
-                },
-                "status": "quality_checked_no_docs"
+                **state,
+                "answer": enhanced_answer,
+                "original_answer": rag_answer,
+                "status": "enhanced"
+            }
+            
+        except Exception as e:
+            debug_print(f"⚠️ RAG 답변 보강 실패: {e}")
+            import traceback
+            debug_print(traceback.format_exc())
+            # 보강 실패 시 기존 RAG 답변 사용
+            debug_print("⚠️ 보강 실패, 원본 RAG 답변 사용")
+            return {
+                **state,
+                "answer": rag_answer,
+                "original_answer": rag_answer,
+                "status": "enhancement_failed"
             }
         
-        # rag_metrics를 직접 사용 (rag_pipeline이 None이어도 사용 가능)
-        if _rag_metrics:
-            try:
-                quality_scores = _rag_metrics.evaluate(
-                    question=question,
-                    answer=answer,
-                    documents=documents
-                )
-                return {
-                    "quality_scores": quality_scores,
-                    "status": "quality_checked"
-                }
-            except Exception as e:
-                debug_print(f"품질 평가 실패: {e}")
-        
-        # rag_pipeline에 rag_metrics가 있는 경우 (하위 호환성)
-        if _rag_pipeline and hasattr(_rag_pipeline, 'rag_metrics'):
-            try:
-                quality_scores = _rag_pipeline.rag_metrics.evaluate(
-                    question=question,
-                    documents=documents,
-                    answer=answer
-                )
-                return {
-                    "quality_scores": quality_scores,
-                    "status": "quality_checked"
-                }
-            except Exception as e:
-                debug_print(f"품질 평가 실패: {e}")
-        
-        # Fallback 평가
-        doc_quality = min(1.0, len(documents) / 3.0)
-        answer_quality = min(1.0, len(answer) / 100.0)
-        
-        question_words = set(question.lower().split())
-        answer_words = set(answer.lower().split())
-        keyword_match = len(question_words.intersection(answer_words)) / max(len(question_words), 1)
-        
-        overall_score = (doc_quality * 0.3 + answer_quality * 0.4 + keyword_match * 0.3)
-        
-        quality_scores = {
-            "retrieval_accuracy": doc_quality,
-            "answer_relevance": answer_quality,
-            "answer_correctness": keyword_match,
-            "hallucination_score": 0.7,
-            "overall_score": overall_score
-        }
-        
-        return {
-            "quality_scores": quality_scores,
-            "status": "fallback_quality_checked"
-        }
-        
     except Exception as e:
-        debug_print(f"==== [QUALITY CHECK ERROR: {e}] ====")
+        debug_print(f"❌ 답변 보강 실패: {e}")
+        import traceback
+        debug_print(traceback.format_exc())
         return {
-            "quality_scores": {
-                "retrieval_accuracy": 0.3,
-                "answer_relevance": 0.3,
-                "answer_correctness": 0.3,
-                "hallucination_score": 0.5,
-                "overall_score": 0.35
-            },
-            "status": "error",
-            "error_message": f"Quality check failed: {str(e)}"
+            **state,
+            "answer": rag_answer,
+            "original_answer": rag_answer,
+            "status": "refinement_failed",
+            "error_message": f"Answer refinement failed: {str(e)}"
         }
 
 
-def llm_judge_validation_node(state: GraphState) -> GraphState:
-    """LLM-as-Judge 통합 검증 노드 - 모든 검증을 LLM이 직접 판단"""
-    debug_print("==== [LLM JUDGE VALIDATION] ====")
+@robust_error_handling(ErrorType.VALIDATION_ERROR)
+def llm_judge_node(state: GraphState) -> GraphState:
+    """LLM Judge 노드 - 답변 품질 평가 및 검증만 수행"""
+    debug_print("==== [LLM JUDGE NODE] ====")
     question = state.get("question", "")
-    answer = state.get("answer", "")
+    refined_answer = state.get("answer", "")  # answer_refinement_node에서 개선된 답변
     documents = state.get("retrieved_docs", state.get("documents", []))
     retry_count = state.get("retry_count", 0)
     route = state.get("route", "vectorstore")
     
     try:
-        if not question or not answer:
-            state["llm_judge_scores"] = {
-                "should_output": False,
-                "needs_correction": True,
-                "reasoning": "답변 또는 질문이 없어 검증 불가",
-                "is_valid": False,
-                "overall_score": 0
-            }
-            state["status"] = "llm_judge_skipped"
-            return state
+        if not refined_answer or refined_answer.strip() == "":
+            debug_print("⚠️ 답변이 없어 평가 건너뜀")
+            return preserve_state_fields(state, {
+                "llm_judge_scores": {
+                    "should_output": False,
+                    "needs_correction": True,
+                    "reasoning": "답변이 없어 평가 불가",
+                    "is_valid": False,
+                    "overall_score": 0
+                },
+                "status": "judge_skipped"
+            })
         
-        # 참조 문서 요약 (웹검색과 벡터스토어 구분)
-        source_summary = ""
-        web_docs = []
-        vector_docs = []
+        if _llm is None:
+            debug_print("⚠️ LLM이 없어 평가 건너뜀")
+            return preserve_state_fields(state, {
+                "llm_judge_scores": {
+                    "should_output": False,
+                    "needs_correction": True,
+                    "reasoning": "LLM이 없어 평가 불가",
+                    "is_valid": False,
+                    "overall_score": 0
+                },
+                "status": "judge_skipped"
+            })
         
+        # 참조 문서 요약
+        doc_summary = ""
         if documents:
+            doc_summary = "\n\n=== 참조 문서 요약 ===\n"
             for i, doc in enumerate(documents[:10]):
-                content = doc.page_content[:500] if hasattr(doc, 'page_content') else str(doc)[:500]
+                content = doc.page_content[:300] if hasattr(doc, 'page_content') else str(doc)[:300]
                 source = doc.metadata.get("source", "Unknown")
-                
-                # 웹검색과 벡터스토어 결과 분리
-                if source.startswith("http"):
-                    web_docs.append(f"웹 검색 결과 {len(web_docs)+1} (출처: {source}):\n{content}...")
-                else:
-                    vector_docs.append(f"벡터스토어 결과 {len(vector_docs)+1} (출처: {source}):\n{content}...")
-            
-            if web_docs:
-                source_summary += "=== 웹 검색 결과 ===\n" + "\n\n".join(web_docs) + "\n\n"
-            if vector_docs:
-                source_summary += "=== 벡터스토어 결과 ===\n" + "\n\n".join(vector_docs)
+                doc_summary += f"\n[문서 {i+1}] 출처: {source}\n{content}...\n"
         
-        # 통합 검증 프롬프트
-        judge_prompt = f"""
-당신은 농업 전문가이자 답변 품질 검증자입니다. 다음 답변을 종합적으로 검증하고 판단하세요.
+        # LLM Judge 프롬프트
+                judge_prompt = f"""
+당신은 농업 전문가이자 답변 품질 검증자입니다. 다음 보강된 RAG 답변을 종합적으로 검증하고 판단하세요.
 
 **질문:** {question}
 
-**생성된 답변:** {answer}
+**보강된 RAG 답변:** {refined_answer}
 
 **참조 문서:**
-{source_summary if source_summary else "참조 문서 없음"}
+{doc_summary if doc_summary else "참조 문서 없음"}
 
 **검색 경로:** {route} (vectorstore 또는 web_search)
 **재시도 횟수:** {retry_count}/3
@@ -384,7 +500,7 @@ def llm_judge_validation_node(state: GraphState) -> GraphState:
 
 농업 정보의 정확성이 매우 중요하므로, 확신이 없으면 should_output을 False로 판단하세요.
 """
-        
+                
         # LLM 사용 가능 여부 확인
         llm_to_use = None
         if _rag_pipeline and hasattr(_rag_pipeline, 'llm') and _rag_pipeline.llm:
@@ -394,21 +510,17 @@ def llm_judge_validation_node(state: GraphState) -> GraphState:
         
         if llm_to_use:
             try:
+                # 구조화된 LLM 호출로 품질 평가 및 판단
                 structured_llm = llm_to_use.with_structured_output(LLMJudgeScores)
-                result = structured_llm.invoke(judge_prompt)
-                result_dict = result.model_dump()
+                judge_result = structured_llm.invoke(judge_prompt)
+                result_dict = judge_result.model_dump()
                 
-                # overall_score 자동 계산 (없는 경우)
-                if "overall_score" not in result_dict or result_dict["overall_score"] == 0:
-                    scores = [
-                        result_dict.get("accuracy", 0),
-                        result_dict.get("completeness", 0),
-                        result_dict.get("logical_consistency", 0),
-                        result_dict.get("usefulness", 0)
-                    ]
-                    result_dict["overall_score"] = int(sum(scores) / len(scores))
+                # overall_score는 LLM이 자동 계산하도록 함 (임계값 없이)
+                if "overall_score" not in result_dict:
+                    debug_print("⚠️ LLM이 overall_score를 계산하지 않음")
+                    result_dict["overall_score"] = 0  # 기본값만 설정
                 
-                # is_valid는 should_output과 동일하게 설정 (하위 호환성)
+                # is_valid는 should_output과 동일하게 설정
                 if "is_valid" not in result_dict:
                     result_dict["is_valid"] = result_dict.get("should_output", False)
                 
@@ -419,63 +531,102 @@ def llm_judge_validation_node(state: GraphState) -> GraphState:
                     result_dict["needs_correction"] = not result_dict.get("should_output", False)
                 if "correction_suggestions" not in result_dict:
                     result_dict["correction_suggestions"] = ""
+                if "reasoning" not in result_dict:
+                    result_dict["reasoning"] = ""
                 
-                debug_print(f"✅ LLM 통합 검증 판단: should_output={result_dict.get('should_output')}, needs_correction={result_dict.get('needs_correction')}")
-                debug_print(f"📊 점수: accuracy={result_dict.get('accuracy')}, completeness={result_dict.get('completeness')}, overall={result_dict.get('overall_score')}")
-                debug_print(f"💭 판단 근거: {result_dict.get('reasoning', '')[:200]}...")
+                debug_print(f"✅ 품질 평가 완료: accuracy={result_dict.get('accuracy')}, completeness={result_dict.get('completeness')}, overall={result_dict.get('overall_score')}")
+                debug_print(f"✅ 최종 판단: should_output={result_dict.get('should_output')}, needs_correction={result_dict.get('needs_correction')}")
                 
-                state["llm_judge_scores"] = result_dict
-                state["status"] = "llm_judge_completed"
-                return state
+                # quality_scores 생성 (하위 호환성)
+                quality_scores = {
+                    "retrieval_accuracy": 0.8 if documents else 0.2,
+                    "answer_relevance": result_dict.get("usefulness", 0) / 100.0,
+                    "answer_correctness": result_dict.get("accuracy", 0) / 100.0,
+                    "hallucination_score": 1.0 if result_dict.get("accuracy", 0) >= 70 else 0.5,
+                    "overall_score": result_dict.get("overall_score", 0) / 100.0,
+                    "evaluation_method": "LLM"
+                }
+                
+                return preserve_state_fields(state, {
+                    "quality_scores": quality_scores,
+                    "llm_judge_scores": {
+                        "accuracy": result_dict.get("accuracy", 0),
+                        "completeness": result_dict.get("completeness", 0),
+                        "logical_consistency": result_dict.get("logical_consistency", 0),
+                        "usefulness": result_dict.get("usefulness", 0),
+                        "overall_score": result_dict.get("overall_score", 0),
+                        "should_output": result_dict.get("should_output", False),
+                        "needs_correction": result_dict.get("needs_correction", True),
+                        "correction_suggestions": result_dict.get("correction_suggestions", ""),
+                        "reasoning": result_dict.get("reasoning", ""),
+                        "is_valid": result_dict.get("is_valid", False)
+                    },
+                    "status": "judged"
+                })
                 
             except Exception as e:
-                debug_print(f"⚠️ LLM 통합 검증 구조화된 출력 실패: {e}")
-                # Fallback: 일반 LLM 호출
-                try:
-                    fallback_response = llm_to_use.invoke(judge_prompt)
-                    response_text = fallback_response.content.lower()
-                    
-                    should_output = "출력 가능" in response_text or "true" in response_text or "yes" in response_text
-                    needs_correction = "수정 필요" in response_text or "false" in response_text or "no" in response_text
-                    
-                    state["llm_judge_scores"] = {
-                        "should_output": should_output,
-                        "needs_correction": needs_correction,
-                        "reasoning": fallback_response.content,
-                        "is_valid": should_output,
-                        "overall_score": 70 if should_output else 50,
-                        "correction_suggestions": ""
-                    }
-                    state["status"] = "llm_judge_fallback"
-                    return state
-                except Exception as e2:
-                    debug_print(f"⚠️ LLM 통합 검증 Fallback 실패: {e2}")
+                debug_print(f"⚠️ 구조화된 출력 실패: {e}, 기본값 사용")
+                # Fallback: 기본값 설정
+                return preserve_state_fields(state, {
+                    "quality_scores": {
+                        "retrieval_accuracy": 0.5,
+                        "answer_relevance": 0.5,
+                        "answer_correctness": 0.5,
+                        "hallucination_score": 0.5,
+                        "overall_score": 0.5,
+                        "evaluation_method": "Fallback"
+                    },
+                        "llm_judge_scores": {
+                            "should_output": True,
+                            "needs_correction": False,
+                        "reasoning": f"구조화된 출력 실패: {str(e)}",
+                            "is_valid": True,
+                        "overall_score": 50
+                    },
+                    "status": "judge_fallback"
+                })
         
-        # LLM이 없는 경우
-        state["llm_judge_scores"] = {
-            "should_output": False,
-            "needs_correction": True,
-            "reasoning": "LLM이 없어 검증 불가",
-            "is_valid": False,
-            "overall_score": 0,
-            "correction_suggestions": ""
-        }
-        state["status"] = "llm_judge_skipped"
-        return state
-            
+        # LLM이 없는 경우 기본값 반환
+        return preserve_state_fields(state, {
+            "quality_scores": {
+                "retrieval_accuracy": 0.3,
+                "answer_relevance": 0.3,
+                "answer_correctness": 0.3,
+                "hallucination_score": 0.5,
+                "overall_score": 0.35,
+                "evaluation_method": "None"
+            },
+            "llm_judge_scores": {
+                "should_output": False,
+                "needs_correction": True,
+                "reasoning": "LLM이 없어 평가 불가",
+                "is_valid": False,
+                "overall_score": 0
+            },
+            "status": "judge_skipped"
+        })
+        
     except Exception as e:
         debug_print(f"==== [LLM JUDGE ERROR: {e}] ====")
-        state["llm_judge_scores"] = {
-            "should_output": False,
-            "needs_correction": True,
-            "reasoning": f"LLM 통합 검증 실패: {str(e)}",
-            "is_valid": False,
-            "overall_score": 0,
-            "correction_suggestions": ""
-        }
-        state["status"] = "llm_judge_error"
-        state["error_message"] = f"LLM Judge failed: {str(e)}"
-        return state
+        return preserve_state_fields(state, {
+            "quality_scores": {
+                "retrieval_accuracy": 0.3,
+                "answer_relevance": 0.3,
+                "answer_correctness": 0.3,
+                "hallucination_score": 0.5,
+                "overall_score": 0.35,
+                "evaluation_method": "Error"
+            },
+            "llm_judge_scores": {
+                "should_output": False,
+                "needs_correction": True,
+                "reasoning": f"오류 발생: {str(e)}",
+                "is_valid": False,
+                "overall_score": 0
+            },
+            "status": "judge_failed",
+            "error_message": f"LLM Judge failed: {str(e)}"
+        })
 
 
 # 라우팅 및 검색 노드들
@@ -484,13 +635,8 @@ def route_question(state):
     """질문을 적절한 데이터 소스로 라우팅하는 노드"""
     debug_print("==== [ROUTE QUESTION] ====")
     question = get_current_question(state)
-    image = get_current_image(state)
     
     try:
-        if image and image != "":
-            debug_print("==== [ROUTE QUESTION TO IMAGE ANALYSIS] ====")
-            return preserve_state_fields(state, {"route": "analyze_image", "status": "routed"})
-
         if _question_router:
             source = _question_router.invoke({"question": question})
             
@@ -532,51 +678,40 @@ def analyze_image(state):
     question = state["question"]
     image_data = state["image"]
 
-    image = Image.open(image_data).convert('RGB')
-    
-    # 예측
-    extended_inputs = image_classification_processor(image, return_tensors="pt")
-    
-    with torch.no_grad():
-        extended_pred = torch.nn.functional.softmax(image_classification_model(**extended_inputs).logits[0], dim=-1)
-    
-    top_idx = extended_pred.argmax()
-    
-    if top_idx.item() in all_classes:
-        class_name = all_classes[top_idx.item()]
-    else:
-        class_name = f"Unknown ({top_idx.item()})"
+    # 이미지 분류 모델이 없는 경우 처리
+    if image_classification_model is None or image_classification_processor is None:
+        debug_print("⚠️ 이미지 분류 모델이 초기화되지 않았습니다.")
+        return {
+            "question": question,
+            "image_result": "이미지 분류 모델을 사용할 수 없습니다.",
+            "documents": []
+        }
 
-    enhanced_question = f"{question}\n\n이미지 분석 결과: {class_name}"
+    try:
+        image = Image.open(image_data).convert('RGB')
+        
+        # 예측
+        extended_inputs = image_classification_processor(image, return_tensors="pt")
+        
+        with torch.no_grad():
+            extended_pred = torch.nn.functional.softmax(image_classification_model(**extended_inputs).logits[0], dim=-1)
+        
+        top_idx = extended_pred.argmax()
+        
+        if top_idx.item() in all_classes:
+            class_name = all_classes[top_idx.item()]
+        else:
+            class_name = f"Unknown ({top_idx.item()})"
+        enhanced_question = f"{question}\n\n이미지 분석 결과: {class_name}"
 
-    return {"question": enhanced_question, "image_result": class_name, "documents": []}
-
-
-
-def decide_image_route(state):
-    """이미지 분석 후 라우팅 결정 함수 (conditional edge용)"""
-    debug_print("==== [DECIDE IMAGE ROUTE] ====")
-    
-    question = state["question"]
-    image_result = state.get("image_result", "")
-
-    if not image_result:
-        debug_print("⚠️ 이미지 분석 결과가 없습니다. web_search로 라우팅합니다.")
-        return "web_search"
-
-    if _image_route_router is None:
-        debug_print("⚠️ 이미지 라우팅 라우터가 초기화되지 않았습니다.")
-        return "web_search"
-    
-    image_source = _image_route_router.invoke({"question": question, "image_result": image_result})
-
-    if image_source.datasource == "web_search":
-        debug_print("==== [IMAGE ROUTE QUESTION TO WEB SEARCH] ====")
-        return "web_search"
-    elif image_source.datasource == "vectorstore":
-        debug_print("==== [IMAGE ROUTE QUESTION TO VECTORSTORE] ====")
-        return "retrieve"  # workflow에서 "retrieve"로 매핑
-
+        return {"question": enhanced_question, "image_result": class_name, "documents": []}
+    except Exception as e:
+        debug_print(f"⚠️ 이미지 분석 실패: {e}")
+        return {
+            "question": question,
+            "image_result": f"이미지 분석 중 오류 발생: {str(e)}",
+            "documents": []
+        }
 
 
 @robust_error_handling(ErrorType.PROCESSING_ERROR)
@@ -628,7 +763,7 @@ def retrieve(state):
 
 @robust_error_handling(ErrorType.VALIDATION_ERROR)
 def check_question_validity(state):
-    """질문의 유효성을 검사하는 노드 (재작성 기능 제거)"""
+    """질문의 유효성을 검사하고 부적합한 경우 ChatGPT로 보강하는 노드"""
     debug_print("==== [CHECK QUESTION VALIDITY] ====")
     question = state.get("question", "")
     
@@ -637,15 +772,29 @@ def check_question_validity(state):
             validation_result = _question_validator.invoke({"question": question})
             
             is_valid = validation_result.validity.lower() == "yes"
+            rewritten_question = validation_result.rewritten_question.strip() if hasattr(validation_result, 'rewritten_question') else question
             
-            result = {
-                "question_valid": is_valid,
-                "stop_reason": validation_result.reasoning if not is_valid else "",
-                "question": question,  # 원본 질문 유지 (재작성 제거)
-                "current_question": question  # 원본 질문 유지
-            }
-            
-            # 재작성 기능 제거 - 원본 질문 그대로 유지
+            # 재작성된 질문이 있고 원본과 다르면 사용
+            if rewritten_question and rewritten_question != question and rewritten_question != "":
+                debug_print(f"📝 질문 재작성: '{question}' → '{rewritten_question}'")
+                result = {
+                    "question_valid": is_valid,
+                    "stop_reason": validation_result.reasoning if not is_valid else "",
+                    "question": rewritten_question,  # 재작성된 질문 사용
+                    "current_question": rewritten_question,  # 재작성된 질문 사용
+                    "original_question": question,  # 원본 질문 저장
+                    "question_was_rewritten": True
+                }
+            else:
+                # 재작성되지 않았거나 원본과 같으면 원본 사용
+                result = {
+                    "question_valid": is_valid,
+                    "stop_reason": validation_result.reasoning if not is_valid else "",
+                    "question": question,
+                    "current_question": question,
+                    "original_question": question,
+                    "question_was_rewritten": False
+                }
             
             return preserve_state_fields(state, result)
         else:
@@ -654,13 +803,17 @@ def check_question_validity(state):
                 return preserve_state_fields(state, {
                     "question_valid": False,
                     "current_question": question,
+                    "original_question": question,
                     "stop_reason": "질문이 너무 짧습니다.",
+                    "question_was_rewritten": False,
                     "status": "validated"
                 })
             else:
                 return preserve_state_fields(state, {
                     "question_valid": True,
                     "current_question": question,
+                    "original_question": question,
+                    "question_was_rewritten": False,
                     "status": "validated"
                 })
     except Exception as e:
@@ -669,6 +822,8 @@ def check_question_validity(state):
         return preserve_state_fields(state, {
             "question_valid": True,
             "current_question": question,
+            "original_question": question,
+            "question_was_rewritten": False,
             "status": "error",
             "error_message": f"Validation failed: {str(e)}"
         })
@@ -886,4 +1041,5 @@ def transform_query_node(state: GraphState) -> GraphState:
             "current_question": question,
             "route": original_route  # 원래 경로 유지
         })
+
 

--- a/수정/prompts.py
+++ b/수정/prompts.py
@@ -234,16 +234,34 @@ def setup_llm_and_prompts(llm=None):
 3. **실용적 조언**: 단계별 실행 방법
 4. **참조 정보**: 사용된 문서 출처 표시 (가능한 경우)
 
-### 3. 전문성 유지
-- **정확한 농업 용어** 사용 (학술적/전문적 표현)
-- **과학적 근거** 기반 설명
+### 3. 전문성과 이해하기 쉬운 표현의 균형
+- **정확한 농업 용어** 사용하되, **일반인도 이해하기 쉽게** 설명하세요
+- 전문 용어를 사용할 때는 **괄호 안에 쉬운 설명**을 함께 제공하세요
+  * 예: "정식(모종을 땅에 심는 것)", "관부(줄기와 뿌리가 만나는 부분)", "활착(뿌리가 땅에 잘 붙어서 자라기 시작하는 것)"
+- **과학적 근거** 기반 설명하되, **복잡한 이론보다는 실용적인 조언** 중심으로 작성
 - **구체적 수치**: 온도, 습도, 농약 사용량, 시기 등 정확한 수치 포함
 - **실용적 조언**: 실제 농업 현장에서 적용 가능한 정보
+- **문장을 짧고 명확하게** 작성하여 읽기 쉽게 하세요
 
-### 4. 경작지 정보 활용
+### 4. 경작지 정보 및 기상 데이터 활용 (필수)
 - 경작지 정보가 있으면 **지역별 특성**을 고려한 답변
 - 기후, 토양, 환경 조건에 맞는 **맞춤형 조언**
 - **지역별 농업 특성** 반영 (예: 남부 지역, 북부 지역 등)
+
+**⚠️ 기상 데이터 활용 (매우 중요)**:
+- 컨텍스트에 **기상 예보 데이터가 포함되어 있으면 반드시 활용**해야 합니다
+- 현재 온도, 습도, 강수량, 풍속 등 **구체적 수치를 명시**하고 이를 바탕으로 조언하세요
+- 예시:
+  * "현재 온도가 XX℃이므로..." 
+  * "습도가 XX%로 높아서..."
+  * "강수량이 XXmm 예상되므로..."
+  * "오늘~3일 예보에 따르면 온도가 XX~XX℃이므로..."
+- 기상 조건에 따른 **구체적이고 실용적인 조언**을 반드시 포함하세요:
+  * 온도가 낮으면: 보온, 관수량 감소, 환기 최소화
+  * 온도가 높으면: 환기 강화, 관수량 증가, 차광
+  * 습도가 높으면: 환기 강화, 병해충 예방 강화
+  * 강수 예상이면: 배수 확인, 환기구 점검
+- **병해충 예측 정보**가 제공되면 이를 반영하여 예방 및 방제 조언 제공
 
 ---
 
@@ -253,6 +271,7 @@ def setup_llm_and_prompts(llm=None):
 3. **일반화된 조언**보다는 **구체적이고 실용적인 정보** 제공
 4. **할루시네이션** (거짓 정보 생성) 절대 금지
 5. **모호한 표현** 피하고 **구체적이고 명확한 정보** 제공
+6. **과도하게 전문적인 용어만 사용**하지 말고, **일반인도 이해할 수 있도록** 쉬운 설명 추가
 
 ---
 
@@ -263,9 +282,9 @@ def setup_llm_and_prompts(llm=None):
 **답변**:
 1. **핵심 답변**: 탄저병 방제를 위한 농약과 사용법
 2. **상세 설명**: 
-   - 사용 가능한 농약: 카브리오, 오티바 등
+   - 사용 가능한 농약: 카브리오, 오티바 등 [구체적인 농약명]
    - 사용 시기: 발병 초기 3일 간격으로 3회 처리
-   - 사용 방법: 엽면 살포
+   - 사용 방법: 엽면 살포 [희석비율, 살포량, 살포방법 등 구체적 방법]
 3. **실용적 조언**:
    - 예방을 위해 정식 전 세균 검사
    - 병 발생 시 즉시 감염 식물 제거
@@ -286,13 +305,40 @@ def setup_llm_and_prompts(llm=None):
 
 이미지 분석 결과: {image_result}
 
-위 정보를 바탕으로 질문에 대한 정확하고 전문적인 답변을 제공해주세요.
+**⚠️ 매우 중요: 기상 데이터 활용 필수**
+
+컨텍스트에 기상 예보 데이터가 포함되어 있다면:
+1. **반드시 기상 조건을 명시**하세요 (예: "현재 온도 XX℃, 습도 XX%")
+2. **기상 조건에 맞춘 구체적 조언**을 제공하세요
+3. **일반적인 조언이 아닌 현재 기상 조건에 맞춘 맞춤형 조언**을 제시하세요
+4. **쉬운 용어로 설명**하되, 전문 용어 사용 시 괄호 안에 설명 추가
+
+예시:
+- 관수량 질문 시: "현재 온도가 XX℃이고 습도가 XX%이므로, 일반적인 관수량보다 XX% 증가/감소하는 것이 좋습니다"
+- 환기 질문 시: "현재 습도가 XX%로 높고 풍속이 XXm/s이므로, 환기(하우스에 바람을 통하게 하는 것)를 XX하게 하는 것을 권장합니다"
+- 온도 관리 질문 시: "오늘~3일 예보에 따르면 온도가 XX~XX℃이므로, 보온(온도를 따뜻하게 유지) 또는 차광(햇빛을 가리는 것) 조치가 필요합니다"
+
+병해충 예측 정보가 포함되어 있다면:
+- 위험도가 높은 병해충에 대한 예방 조치를 강조하세요
+- 예보 기간 내 위험 시간대를 고려한 조언을 제공하세요
+
+**💡 답변 작성 시 주의사항:**
+- 전문 용어 사용 시 괄호 안에 쉬운 설명 추가 (예: "정식(모종 심기)", "활착(뿌리가 땅에 붙어 자라기 시작)")
+- 문장을 짧고 명확하게 작성
+- 일반인도 이해할 수 있는 쉬운 표현 사용
+- 복잡한 이론보다는 실용적인 조언 중심
+
+**⚠️ 현재 날짜 및 시기 고려 (매우 중요):**
+- 컨텍스트에 현재 날짜 정보가 포함되어 있다면, **반드시 현재 시기를 고려**하여 답변하세요
+- **현재 시기에 맞지 않는 작업이나 정보는 제외**하세요
+  * 예: 현재가 11월인데 "정식 시기가 다가오고 있으므로" 같은 표현은 사용하지 마세요
+  * 예: 현재가 겨울인데 "파종 준비" 같은 봄 작업을 언급하지 마세요
+- **현재 시기에 맞는 작업과 관리 방법만** 제시하세요
+- 컨텍스트에 여러 시기의 정보가 포함되어 있어도, **현재 날짜 기준으로 필터링**하여 답변하세요
+
+위 정보를 바탕으로 질문에 대한 정확하고 **이해하기 쉬운**, **현재 시기에 맞는** 답변을 제공해주세요.
         """),
     ])
-
-
-
-
     
     # 평가용 프롬프트들
     grade_documents_prompt = ChatPromptTemplate.from_messages([
@@ -338,24 +384,16 @@ def setup_llm_and_prompts(llm=None):
         """),
         ("human", "사용자 질문: {question} \n\n LLM 생성 답변: {generation}"),
     ])
-    
-    image_route_prompt = ChatPromptTemplate.from_messages([
-        ("system", """You are an expert at routing a user question to a vectorstore, web search
-The vectorstore contains documents related to Crop cultivation, pest diagnosis, pesticide and fertilizer(compost)
-Use the vectorstore for questions on these topics.
-Otherwise, use web-search.""",),
-        ("human", "사용자 질문: {question} \n 이미지 분석 결과: {image_result}"),
-    ])
+
 
 
     # LLM 기반 평가를 위한 structured output 체인 생성 (프롬프트와 결합)
-    from .models import GradeDocuments, GradeHallucinations, GradeAnswer, ImageRouteQuery
+    from .models import GradeDocuments, GradeHallucinations, GradeAnswer
     
     # 프롬프트와 structured output을 결합한 체인 생성
     grade_documents_grader = grade_documents_prompt | llm.with_structured_output(GradeDocuments)
     hallucination_grader = hallucination_grader_prompt | llm.with_structured_output(GradeHallucinations)
     answer_grader = answer_grader_prompt | llm.with_structured_output(GradeAnswer)
-    image_route_router = image_route_prompt | llm.with_structured_output(ImageRouteQuery)
     rag_chain = rag_prompt | llm | StrOutputParser()
 
     return {
@@ -370,7 +408,6 @@ Otherwise, use web-search.""",),
         "grade_documents_grader": grade_documents_grader,
         "hallucination_grader": hallucination_grader,
         "answer_grader": answer_grader,
-        # 이미지 분석 체인
-        "image_route_router": image_route_router,
         "rag_chain": rag_chain,
     }
+

--- a/수정/workflow.py
+++ b/수정/workflow.py
@@ -9,13 +9,10 @@ from .nodes import (
     retrieval_node,
     augmentation_node,
     generation_node,
-    quality_check_node,
-    llm_judge_validation_node,
     route_question,
     retrieve,
     check_question_validity,
     analyze_image,
-    decide_image_route
 )
 
 
@@ -25,7 +22,9 @@ def decide_validity(state: GraphState) -> str:
     if is_valid:
         return "route_question"
     else:
-        return END
+        # 유효성 검사 실패 시 web_search로 라우팅
+        debug_print("⚠️ 질문 유효성 검사 실패, web_search로 라우팅")
+        return "web_search"
 
 
 def has_image(state: GraphState) -> bool:
@@ -34,14 +33,21 @@ def has_image(state: GraphState) -> bool:
     return image and image != "" and image is not None
 
 
+def decide_start_route(state: GraphState) -> str:
+    """시작 시 이미지 존재 여부에 따른 라우팅 결정"""
+    if has_image(state):
+        debug_print("이미지를 확인했습니다. analyze_image")
+        return "analyze_image"
+    else:
+        debug_print("이미지가 없습니다. check_validity")
+        return "check_validity"
+
+
 def decide_route(state: GraphState) -> str:
     """라우팅 결정을 위한 조건부 엣지 함수"""
     route = state.get("route", "web_search")  # 원래 기본값 유지
     
     debug_print(f"Route decision: {route}")
-    
-    if has_image(state):
-        return "analyze_image"
 
     # 하이브리드 검색 제거 - 단순 라우팅만 수행
     if route == "vectorstore":
@@ -50,28 +56,50 @@ def decide_route(state: GraphState) -> str:
         return "web_search"
 
 
-def decide_quality(state: GraphState) -> str:
-    """품질 점수에 따른 재처리 결정"""
-    quality_scores = state.get("quality_scores", {})
-    overall_score = quality_scores.get("overall_score", 0.0)
-    retry_count = state.get("retry_count", 0)
+def decide_document_availability(state: GraphState) -> str:
+    """문서 존재 여부에 따른 라우팅 결정"""
+    documents = state.get("retrieved_docs", state.get("documents", []))
+    route = state.get("route", "vectorstore")
     
-    if overall_score < 0.7 and retry_count < 2:
-        debug_print(f"Quality too low ({overall_score:.3f}), retrying...")
-        return "transform_query_node"
-    else:
-        return END
+    # 문서가 없고 원래 경로가 vectorstore면 web_search로 전환
+    if not documents and route == "vectorstore":
+        debug_print("⚠️ 벡터스토어에서 문서를 찾지 못함, web_search로 전환")
+        return "web_search"
+    
+    # 문서가 있으면 계속 진행
+    return "generation_node"
+
+
+def decide_retry_route(state: GraphState) -> str:
+    """재검색 시 경로 결정 (재시도 횟수에 따라 경로 전환)"""
+    retry_count = state.get("retry_count", 0)
+    route = state.get("route", "vectorstore")
+    
+    # 재시도 2회 이상이고 벡터스토어였으면 web_search로 전환
+    if retry_count >= 2 and route == "vectorstore":
+        debug_print(f"⚠️ 재시도 {retry_count}회, 벡터스토어에서 웹검색으로 전환")
+        return "web_search"
+    
+    # 원래 경로 유지
+    return route
 
 
 def decide_final_quality(state: GraphState) -> str:
     """최종 품질 결정 - LLM 판단 직접 사용 (임계값 제거)"""
     llm_judge_scores = state.get("llm_judge_scores", {})
     retry_count = state.get("retry_count", 0)
+    route = state.get("route", "vectorstore")
+    documents = state.get("retrieved_docs", state.get("documents", []))
     
     MAX_RETRIES = 3
     if retry_count >= MAX_RETRIES:
         debug_print(f"최대 재시도 횟수 도달 ({retry_count}/{MAX_RETRIES})")
         return END
+    
+    # 문서가 없고 벡터스토어였으면 web_search로 전환
+    if not documents and route == "vectorstore" and retry_count >= 1:
+        debug_print("⚠️ 문서 없음 + 재시도 중, web_search로 전환")
+        return "web_search"
     
     # LLM의 직접 판단 사용
     should_output = llm_judge_scores.get("should_output", False)
@@ -107,6 +135,8 @@ def create_workflow(nodes_dict: dict):
     # 노드 추가
     if "check_validity" in nodes_dict:
         workflow.add_node("check_validity", nodes_dict["check_validity"])
+    if "assess_complexity_node" in nodes_dict:
+        workflow.add_node("assess_complexity_node", nodes_dict["assess_complexity_node"])
     if "route_question" in nodes_dict:
         workflow.add_node("route_question", nodes_dict["route_question"])
     if "retrieve" in nodes_dict:
@@ -119,24 +149,63 @@ def create_workflow(nodes_dict: dict):
         workflow.add_node("augmentation_node", nodes_dict["augmentation_node"])
     if "generation_node" in nodes_dict:
         workflow.add_node("generation_node", nodes_dict["generation_node"])
-    if "quality_check_node" in nodes_dict:
-        workflow.add_node("quality_check_node", nodes_dict["quality_check_node"])
-    if "llm_judge_validation" in nodes_dict:
-        workflow.add_node("llm_judge_validation", nodes_dict["llm_judge_validation"])
+    if "answer_refinement_node" in nodes_dict:
+        workflow.add_node("answer_refinement_node", nodes_dict["answer_refinement_node"])
+    if "llm_judge_node" in nodes_dict:
+        workflow.add_node("llm_judge_node", nodes_dict["llm_judge_node"])
+    if "transform_query_node" in nodes_dict:
+        workflow.add_node("transform_query_node", nodes_dict["transform_query_node"])
     if "analyze_image" in nodes_dict:
         workflow.add_node("analyze_image", nodes_dict["analyze_image"])
     
     # 워크플로우 연결
-    workflow.add_edge(START, "check_validity")
-    
-    workflow.add_conditional_edges(
-        "check_validity",
-        decide_validity,
-        {
-            "route_question": "route_question",
-            END: END
+    if "analyze_image" in nodes_dict:
+        start_route_mapping = {
+            "check_validity": "check_validity",
+            "analyze_image": "analyze_image",
         }
-    )
+        workflow.add_conditional_edges(
+            START,
+            decide_start_route,
+            start_route_mapping
+        )
+        workflow.add_edge("analyze_image", "check_validity")
+    else:
+        workflow.add_edge(START, "check_validity")
+    
+    # check_validity 후 복잡도 평가 또는 라우팅으로 분기
+    if "assess_complexity_node" in nodes_dict:
+        # 복잡도 평가가 있는 경우: check_validity → assess_complexity → route_question
+        def decide_validity_with_complexity(state: GraphState) -> str:
+            """질문 유효성에 따른 라우팅 결정 (복잡도 평가 포함)"""
+            is_valid = state.get("question_valid", True)
+            if is_valid:
+                return "assess_complexity_node"
+            else:
+                # 유효성 검사 실패 시 web_search로 라우팅
+                debug_print("⚠️ 질문 유효성 검사 실패, web_search로 라우팅")
+                return "web_search"
+        
+        workflow.add_conditional_edges(
+            "check_validity",
+            decide_validity_with_complexity,
+            {
+                "assess_complexity_node": "assess_complexity_node",
+                "web_search": "web_search" if "web_search" in nodes_dict else "retrieval_node"
+            }
+        )
+        # 복잡도 평가 후 라우팅으로
+        workflow.add_edge("assess_complexity_node", "route_question")
+    else:
+        # 복잡도 평가가 없는 경우: check_validity → route_question
+        workflow.add_conditional_edges(
+            "check_validity",
+            decide_validity,
+            {
+                "route_question": "route_question",
+                "web_search": "web_search" if "web_search" in nodes_dict else "retrieval_node"
+            }
+        )
     
     # decide_route 함수가 반환할 수 있는 값들만 포함
     route_mapping = {
@@ -147,9 +216,6 @@ def create_workflow(nodes_dict: dict):
     if "web_search" in nodes_dict:
         route_mapping["web_search"] = "web_search"
 
-    if "analyze_image" in nodes_dict:
-        route_mapping["analyze_image"] = "analyze_image"
-    
     # decide_route 함수를 래핑하여 존재하지 않는 노드에 대한 fallback 처리
     # route_mapping을 먼저 생성한 후 래핑 함수 내부에서 사용
     def safe_decide_route(state: GraphState) -> str:
@@ -167,80 +233,64 @@ def create_workflow(nodes_dict: dict):
         route_mapping
     )
 
-    if "analyze_image" in nodes_dict:
-    # image_analysis 후 직접 라우팅
-        image_route_mapping = {
-            "retrieve": "retrieve"
-        }
     
-        if "web_search" in nodes_dict:
-            image_route_mapping["web_search"] = "web_search"
+    # 검색 → RAG 핵심 검색 (transform_query_node는 피드백 루프에서만 사용)
+    # 복잡도 평가는 이미 라우팅 전에 완료되었으므로, 검색 후 바로 retrieval_node로 연결
+    workflow.add_edge("retrieve", "retrieval_node")
+    # 노드가 있는 경우에만 엣지 추가
+    if "web_search" in nodes_dict:
+        workflow.add_edge("web_search", "retrieval_node")
     
+    # transform_query_node는 피드백 루프에서만 사용 (재시도 횟수에 따라 경로 전환)
+    if "transform_query_node" in nodes_dict:
+        # transform_query_node 후 재시도 횟수에 따라 경로 결정
         workflow.add_conditional_edges(
-            "analyze_image",
-            decide_image_route,  # 라우팅 함수 사용
-            image_route_mapping
+            "transform_query_node",
+            decide_retry_route,  # 재시도 횟수에 따라 경로 전환
+            {
+                "retrieve": "retrieve",
+                "web_search": "web_search" if "web_search" in nodes_dict else "retrieve",
+            }
         )
-    
-    # 검색 → 복잡도 평가 → RAG 핵심 검색 (transform_query_node는 피드백 루프에서만 사용)
-    if "assess_complexity_node" in nodes_dict:
-        workflow.add_node("assess_complexity_node", nodes_dict["assess_complexity_node"])
-        workflow.add_edge("retrieve", "assess_complexity_node")
-        # 노드가 있는 경우에만 엣지 추가
-        if "web_search" in nodes_dict:
-            workflow.add_edge("web_search", "assess_complexity_node")
-        
-        # assess_complexity_node에서 retrieval_node로 직접 연결 (transform_query_node 건너뛰기)
-        workflow.add_edge("assess_complexity_node", "retrieval_node")
-        
-        # transform_query_node는 피드백 루프에서만 사용 (원래 검색 경로로 재검색)
-        if "transform_query_node" in nodes_dict:
-            workflow.add_node("transform_query_node", nodes_dict["transform_query_node"])
-            # transform_query_node 후 원래 검색 경로로 재검색
-            workflow.add_conditional_edges(
-                "transform_query_node",
-                decide_route,  # 원래 검색 경로 확인
-                {
-                    "retrieve": "retrieve",
-                    "web_search": "web_search" if "web_search" in nodes_dict else "retrieve",
-                    "analyze_image": "analyze_image" if "analyze_image" in nodes_dict else "retrieve"
-                }
-            )
-    else:
-        workflow.add_edge("retrieve", "retrieval_node")
-        # 노드가 있는 경우에만 엣지 추가
-        if "web_search" in nodes_dict:
-            workflow.add_edge("web_search", "retrieval_node")
-        
-        # transform_query_node는 피드백 루프에서만 사용 (원래 검색 경로로 재검색)
-        if "transform_query_node" in nodes_dict:
-            workflow.add_node("transform_query_node", nodes_dict["transform_query_node"])
-            # transform_query_node 후 원래 검색 경로로 재검색
-            workflow.add_conditional_edges(
-                "transform_query_node",
-                decide_route,  # 원래 검색 경로 확인
-                {
-                    "retrieve": "retrieve",
-                    "web_search": "web_search" if "web_search" in nodes_dict else "retrieve",
-                    "analyze_image": "analyze_image" if "analyze_image" in nodes_dict else "retrieve"
-                }
-            )
     
     # RAG 핵심 흐름
     workflow.add_edge("retrieval_node", "augmentation_node")
-    workflow.add_edge("augmentation_node", "generation_node")
-    workflow.add_edge("generation_node", "quality_check_node")
-    workflow.add_edge("quality_check_node", "llm_judge_validation")
     
-    # LLM Judge 검증에 따른 최종 분기
-    workflow.add_conditional_edges(
-        "llm_judge_validation",
-        decide_final_quality,
-        {
-            "transform_query_node": "transform_query_node" if "transform_query_node" in nodes_dict else "retrieval_node",
-            END: END
-        }
-    )
+    # augmentation_node 후 문서 존재 여부 확인
+    # 문서가 없고 원래 경로가 vectorstore면 web_search로 전환
+    if "web_search" in nodes_dict:
+        workflow.add_conditional_edges(
+            "augmentation_node",
+            decide_document_availability,
+            {
+                "generation_node": "generation_node",
+                "web_search": "web_search"
+            }
+        )
+    else:
+        # web_search 노드가 없으면 그냥 진행
+        workflow.add_edge("augmentation_node", "generation_node")
+    
+    # 답변 정리 노드 추가
+    if "answer_refinement_node" in nodes_dict:
+        workflow.add_edge("generation_node", "answer_refinement_node")
+        
+        # LLM Judge 노드가 있는 경우: answer_refinement_node → llm_judge_node → decide_final_quality
+        if "llm_judge_node" in nodes_dict:
+            workflow.add_edge("answer_refinement_node", "llm_judge_node")
+            workflow.add_conditional_edges(
+                "llm_judge_node",
+                decide_final_quality,
+                {
+                    "transform_query_node": "transform_query_node" if "transform_query_node" in nodes_dict else "retrieval_node",
+                    END: END
+                }
+            )
+        else:
+            # llm_judge_node가 없는 경우 answer_refinement_node에서 직접 종료
+            workflow.add_edge("answer_refinement_node", END)
+    else:
+        # answer_refinement_node가 없는 경우 generation_node에서 직접 종료
+        workflow.add_edge("generation_node", END)
     
     return workflow.compile()
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors RAG workflow to add weather/pest-aware context, answer refinement and LLM-based judging, start-of-flow image analysis, and dynamic routing/fallbacks while removing old metrics-based quality checks.
> 
> - **Workflow**:
>   - Start routing now checks for images first (`analyze_image` before `check_validity`).
>   - Invalid questions route to `web_search` instead of ending.
>   - Adds `answer_refinement_node` then `llm_judge_node`; removes `quality_check_node` and `llm_judge_validation`.
>   - Adds retry-aware `transform_query_node` with route switching; switches to `web_search` when no docs from vectorstore.
> - **Nodes**:
>   - `generation_node`: injects current date/season, location, weather, and pest-forecast context.
>   - New `answer_refinement_node` (LLM-only polish without adding new info) and revamped `llm_judge_node` (structured evaluation, quality scores output).
>   - `check_question_validity`: supports question rewriting and tracks original/flags.
>   - `analyze_image`: robust error handling and no routing dependency; `augmentation_node` uses `utils.format_docs`.
> - **Models/Prompts**:
>   - `RouteQuery` restricted to `vectorstore|web_search`; remove `ImageRouteQuery`.
>   - `GraphState` adds `original_answer`.
>   - Prompt updates emphasize weather usage and clearer, user-friendly language; remove image route prompt.
> - **Initialization (main)**:
>   - Initialize and pass `WeatherForecastManager` and `PestForecastPredictor` to nodes.
>   - Remove `RAGMetrics` usage; update nodes map accordingly and enhanced result printing (original vs refined).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 396c8fa63755b647d5d90b8293b792a28c2c6875. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->